### PR TITLE
DVISA-2440: WADO RS support

### DIFF
--- a/packages/dicomImageLoader/package.json
+++ b/packages/dicomImageLoader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-dicom-image-loader",
-  "version": "1.86.0-ded8",
+  "version": "1.86.0-ded9",
   "description": "Cornerstone Image Loader for DICOM WADO-URI and WADO-RS and Local file",
   "keywords": [
     "DICOM",

--- a/packages/dicomImageLoader/src/imageLoader/wadors/register.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadors/register.ts
@@ -1,8 +1,12 @@
-import loadImage from './loadImage';
-import { metaDataProvider } from './metaData/index';
+import { loadImage } from '../wadouri/loadImage';
+import { metaDataProvider } from '../wadouri/metaData/index';
 
+/**
+ * Register wadors scheme and metadata provider.
+ * NOTE: currently, wadouri loadImage and metadataProvider are used also for wadors
+ * (see imports). For more information see:
+ */
 export default function (cornerstone) {
-  // register wadors scheme and metadata provider
   cornerstone.registerImageLoader('wadors', loadImage);
   cornerstone.metaData.addProvider(metaDataProvider);
 }

--- a/packages/dicomImageLoader/src/imageLoader/wadors/register.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadors/register.ts
@@ -4,7 +4,7 @@ import { metaDataProvider } from '../wadouri/metaData/index';
 /**
  * Register wadors scheme and metadata provider.
  * NOTE: currently, wadouri loadImage and metadataProvider are used also for wadors
- * (see imports). For more information see:
+ * (see imports). For more information see: https://github.com/DedalusDIIT/cornerstone3D/pull/14
  */
 export default function (cornerstone) {
   cornerstone.registerImageLoader('wadors', loadImage);

--- a/packages/dicomImageLoader/src/imageLoader/wadouri/loadImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/loadImage.ts
@@ -158,7 +158,7 @@ function loadImageFromDataSet(
 }
 
 function getLoaderForScheme(scheme: string): LoadRequestFunction {
-  if (scheme === 'dicomweb' || scheme === 'wadouri') {
+  if (scheme === 'dicomweb' || scheme === 'wadouri' || scheme === 'wadors') {
     return xhrRequest;
   } else if (scheme === 'dicomfile') {
     return loadFileRequest;

--- a/packages/dicomImageLoader/src/imageLoader/wadouri/parseImageId.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/parseImageId.ts
@@ -5,38 +5,38 @@ export interface CornerstoneImageUrl {
   pixelDataFrame: number;
 }
 
+// build a url by parsing out the url scheme and frame index from the imageId
 function parseImageId(imageId: string): CornerstoneImageUrl {
-  // build a url by parsing out the url scheme and frame index from the imageId
   const firstColonIndex = imageId.indexOf(':');
-
-  let url = imageId.substring(firstColonIndex + 1);
-  const frameIndex = url.indexOf('frame=');
-
-  let frame;
-
-  if (frameIndex !== -1) {
-    const frameStr = url.substring(frameIndex + 6);
-
-    frame = parseInt(frameStr, 10);
-    url = url.substring(0, frameIndex - 1);
-  }
-
   const scheme = imageId.substring(0, firstColonIndex);
+  let url = imageId.substring(firstColonIndex + 1);
+
+  // Identify and parse the frame index
+  const framePatterns = [
+    { pattern: 'frame=', offset: 'frame='.length },
+    { pattern: 'frames/', offset: 'frames/'.length },
+  ];
+
+  let frame: number | undefined;
+  framePatterns.some(({ pattern, offset }) => {
+    const frameIndex = url.indexOf(pattern);
+    if (frameIndex !== -1) {
+      frame = parseInt(url.substring(frameIndex + offset), 10);
+      url = url.substring(0, frameIndex - 1); // Remove frame part from the URL
+      return true;
+    }
+    return false;
+  });
+
   /**
    * Why we adjust frameNumber? since in the above we are extracting the
    * frame number from the imageId (from the metadata), and the frame number
    * starts from 1, but in the loader which uses the dicomParser
    * the frame number starts from 0.
    */
+  const pixelDataFrame = frame !== undefined ? frame - 1 : undefined;
 
-  const adjustedFrame = frame !== undefined ? frame - 1 : undefined;
-
-  return {
-    scheme,
-    url,
-    frame,
-    pixelDataFrame: adjustedFrame,
-  };
+  return { scheme, url, frame, pixelDataFrame };
 }
 
 export default parseImageId;

--- a/packages/dicomImageLoader/src/imageLoader/wadouri/retrieveMultiframeDataset.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/retrieveMultiframeDataset.ts
@@ -26,7 +26,9 @@ function _isMultiframeDataset(dataSet) {
 }
 
 function retrieveFrameParameterIndex(uri) {
-  return uri.indexOf('&frame=');
+  return uri.indexOf('&frame=') !== -1
+    ? uri.indexOf('&frame=')
+    : uri.indexOf('frames/');
 }
 
 function retrieveMultiframeDataset(uri) {


### PR DESCRIPTION
This PR updates the WADO RS image loading mechanism and metadata provider to redirect to WADO URI methods within the `register.ts` method.

### **Background**:
Cornerstone's WADO RS loader assumes each WADO RS request returns a `multipart/related; type="application/octet-stream"` response. This format, containing only pixel data, is interpreted solely as image data, leading to immediate rendering attempts without the necessary metadata. To manage metadata, a separate request is typically required, as metadata is essential for accurate image processing.

### **Issue**: 
Our server (as well as Orthanc) returns `multipart/related; type="application/dicom"` responses, which include the complete DICOM instance (both metadata and pixel data). The WADO URI method correctly handles this response type, but adjustments were necessary:

- **Multipart header extraction** was added to handle the multipart application/dicom format.
- **Image ID parsing** was refined to accommodate multiframe requests ("&frame=" vs. "/frames/" syntax).