### PR TITLE
DVISA-2573: async methods for color image pixel data transformation

### DIFF
--- a/packages/dicomImageLoader/package.json
+++ b/packages/dicomImageLoader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-dicom-image-loader",
-  "version": "1.86.0-ded9",
+  "version": "1.86.0-ded10",
   "description": "Cornerstone Image Loader for DICOM WADO-URI and WADO-RS and Local file",
   "keywords": [
     "DICOM",

--- a/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertPALETTECOLOR.ts
+++ b/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertPALETTECOLOR.ts
@@ -42,11 +42,11 @@ function fetchPaletteData(imageFrame, color, fallback) {
  * @param colorBuffer - The buffer to write the converted pixel data to
  * @returns
  */
-export default function (
+export default async function (
   imageFrame: ImageFrame,
   colorBuffer: ByteArray,
   useRGBA: boolean
-): void {
+): Promise<void> {
   const numPixels = imageFrame.columns * imageFrame.rows;
   const pixelData = imageFrame.pixelData;
 

--- a/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertRGBColorByPixel.ts
+++ b/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertRGBColorByPixel.ts
@@ -1,10 +1,10 @@
 import { ByteArray } from 'dicom-parser';
 
-export default function (
+export default async function (
   imageFrame: ByteArray,
   colorBuffer: ByteArray,
   useRGBA: boolean
-): void {
+): Promise<void> {
   if (imageFrame === undefined) {
     throw new Error('decodeRGB: rgbBuffer must be defined');
   }

--- a/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertRGBColorByPlane.ts
+++ b/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertRGBColorByPlane.ts
@@ -1,10 +1,10 @@
 import { ByteArray } from 'dicom-parser';
 
-export default function (
+export default async function (
   imageFrame: ByteArray,
   colorBuffer: ByteArray,
   useRGBA: boolean
-): void {
+): Promise<void> {
   if (imageFrame === undefined) {
     throw new Error('decodeRGB: rgbBuffer must be defined');
   }

--- a/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertYBRFull422ByPixel.ts
+++ b/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertYBRFull422ByPixel.ts
@@ -1,10 +1,10 @@
 import { ByteArray } from 'dicom-parser';
 
-export default function (
+export default async function (
   imageFrame: ByteArray,
   colorBuffer: ByteArray,
   useRGBA: boolean
-): void {
+): Promise<void> {
   if (imageFrame === undefined) {
     throw new Error('convertYBRFull422ByPixel: ybrBuffer must be defined');
   }

--- a/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertYBRFullByPixel.ts
+++ b/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertYBRFullByPixel.ts
@@ -1,10 +1,10 @@
 import { ByteArray } from 'dicom-parser';
 
-export default function (
+export default async function (
   imageFrame: ByteArray,
   colorBuffer: ByteArray,
   useRGBA: boolean
-): void {
+): Promise<void> {
   if (imageFrame === undefined) {
     throw new Error('convertYBRFullByPixel: ybrBuffer must be defined');
   }

--- a/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertYBRFullByPlane.ts
+++ b/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertYBRFullByPlane.ts
@@ -1,10 +1,10 @@
 import { ByteArray } from 'dicom-parser';
 
-export default function (
+export default async function (
   imageFrame: ByteArray,
   colorBuffer: ByteArray,
   useRGBA: boolean
-): void {
+): Promise<void> {
   if (imageFrame === undefined) {
     throw new Error('convertYBRFullByPlane: ybrBuffer must be defined');
   }

--- a/packages/dicomImageLoader/src/imageLoader/convertColorSpace.ts
+++ b/packages/dicomImageLoader/src/imageLoader/convertColorSpace.ts
@@ -7,36 +7,40 @@ import {
   convertPALETTECOLOR,
 } from './colorSpaceConverters/index';
 
-function convertRGB(imageFrame, colorBuffer, useRGBA) {
+async function convertRGB(imageFrame, colorBuffer, useRGBA) {
   if (imageFrame.planarConfiguration === 0) {
-    convertRGBColorByPixel(imageFrame.pixelData, colorBuffer, useRGBA);
+    await convertRGBColorByPixel(imageFrame.pixelData, colorBuffer, useRGBA);
   } else {
-    convertRGBColorByPlane(imageFrame.pixelData, colorBuffer, useRGBA);
+    await convertRGBColorByPlane(imageFrame.pixelData, colorBuffer, useRGBA);
   }
 }
 
-function convertYBRFull(imageFrame, colorBuffer, useRGBA) {
+async function convertYBRFull(imageFrame, colorBuffer, useRGBA) {
   if (imageFrame.planarConfiguration === 0) {
-    convertYBRFullByPixel(imageFrame.pixelData, colorBuffer, useRGBA);
+    await convertYBRFullByPixel(imageFrame.pixelData, colorBuffer, useRGBA);
   } else {
-    convertYBRFullByPlane(imageFrame.pixelData, colorBuffer, useRGBA);
+    await convertYBRFullByPlane(imageFrame.pixelData, colorBuffer, useRGBA);
   }
 }
 
-export default function convertColorSpace(imageFrame, colorBuffer, useRGBA) {
+export default async function convertColorSpace(
+  imageFrame,
+  colorBuffer,
+  useRGBA
+) {
   // convert based on the photometric interpretation
   if (imageFrame.photometricInterpretation === 'RGB') {
-    convertRGB(imageFrame, colorBuffer, useRGBA);
+    await convertRGB(imageFrame, colorBuffer, useRGBA);
   } else if (imageFrame.photometricInterpretation === 'YBR_RCT') {
-    convertRGB(imageFrame, colorBuffer, useRGBA);
+    await convertRGB(imageFrame, colorBuffer, useRGBA);
   } else if (imageFrame.photometricInterpretation === 'YBR_ICT') {
-    convertRGB(imageFrame, colorBuffer, useRGBA);
+    await convertRGB(imageFrame, colorBuffer, useRGBA);
   } else if (imageFrame.photometricInterpretation === 'PALETTE COLOR') {
-    convertPALETTECOLOR(imageFrame, colorBuffer, useRGBA);
+    await convertPALETTECOLOR(imageFrame, colorBuffer, useRGBA);
   } else if (imageFrame.photometricInterpretation === 'YBR_FULL_422') {
-    convertYBRFull422ByPixel(imageFrame.pixelData, colorBuffer, useRGBA);
+    await convertYBRFull422ByPixel(imageFrame.pixelData, colorBuffer, useRGBA);
   } else if (imageFrame.photometricInterpretation === 'YBR_FULL') {
-    convertYBRFull(imageFrame, colorBuffer, useRGBA);
+    await convertYBRFull(imageFrame, colorBuffer, useRGBA);
   } else {
     // TODO - handle YBR_PARTIAL and 420 colour spaces
     throw new Error(

--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -170,7 +170,7 @@ function createImage(
 
   return new Promise<DICOMLoaderIImage | ImageFrame>((resolve, reject) => {
     // eslint-disable-next-line complexity
-    decodePromise.then(function (imageFrame: ImageFrame) {
+    decodePromise.then(async function (imageFrame: ImageFrame) {
       // if it is desired to skip creating image, return the imageFrame
       // after the decode. This might be useful for some applications
       // that only need the decoded pixel data and not the image object
@@ -262,7 +262,7 @@ function createImage(
             imageFrame.rows
           );
 
-          convertColorSpace(imageFrame, imageData.data, useRGBA);
+          await convertColorSpace(imageFrame, imageData.data, useRGBA);
           imageFrame.imageData = imageData;
           imageFrame.pixelData = imageData.data;
           imageFrame.pixelDataLength = imageData.data.length;
@@ -293,7 +293,7 @@ function createImage(
 
         /** @todo check as any */
         // calculate smallest and largest PixelValue of the converted pixelData
-        const minMax = getMinMax(imageFrame.pixelData as any);
+        const minMax = getMinMax(imageFrame.pixelData);
 
         imageFrame.smallestPixelValue = minMax.min;
         imageFrame.largestPixelValue = minMax.max;


### PR DESCRIPTION
Added `async`/`await` to he methods that convert the pixel data of the color images. 

The methods take some time, so the code that was executed after them was not working with the converted pixel data. 