### PR TITLE
DVISA-2605: add WADO-URI multi-frame parameters to parseImageId

### DIFF
--- a/packages/dicomImageLoader/package.json
+++ b/packages/dicomImageLoader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-dicom-image-loader",
-  "version": "1.86.0-ded10",
+  "version": "1.86.0-ded11",
   "description": "Cornerstone Image Loader for DICOM WADO-URI and WADO-RS and Local file",
   "keywords": [
     "DICOM",

--- a/packages/dicomImageLoader/src/imageLoader/wadouri/parseImageId.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/parseImageId.ts
@@ -7,14 +7,27 @@ export interface CornerstoneImageUrl {
 
 // build a url by parsing out the url scheme and frame index from the imageId
 function parseImageId(imageId: string): CornerstoneImageUrl {
+  if (!imageId) {
+    return {
+      scheme: '',
+      url: '',
+      frame: 0,
+      pixelDataFrame: 0,
+    };
+  }
+
   const firstColonIndex = imageId.indexOf(':');
   const scheme = imageId.substring(0, firstColonIndex);
   let url = imageId.substring(firstColonIndex + 1);
+  const contentTypeMatch = url.match(/(&contentType=[^&]*)/);
+  const transferSyntaxMatch = url.match(/(&transferSyntax=[^&]*)/);
 
   // Identify and parse the frame index
   const framePatterns = [
     { pattern: 'frame=', offset: 'frame='.length },
     { pattern: 'frames/', offset: 'frames/'.length },
+    { pattern: 'simpleFrameList=', offset: 'simpleFrameList='.length },
+    { pattern: 'frameNumber=', offset: 'frameNumber='.length },
   ];
 
   let frame: number | undefined;
@@ -23,6 +36,12 @@ function parseImageId(imageId: string): CornerstoneImageUrl {
     if (frameIndex !== -1) {
       frame = parseInt(url.substring(frameIndex + offset), 10);
       url = url.substring(0, frameIndex - 1); // Remove frame part from the URL
+      if (contentTypeMatch) {
+        url += contentTypeMatch[1];
+      }
+      if (transferSyntaxMatch) {
+        url += transferSyntaxMatch[1];
+      }
       return true;
     }
     return false;

--- a/packages/dicomImageLoader/src/imageLoader/wadouri/parseImageId_test.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/parseImageId_test.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import parseImageId from './parseImageId';
+
+describe('parseImageId', () => {
+  it('should handle empty imageId', () => {
+    const result = parseImageId('');
+    expect(result.scheme).to.equal('');
+    expect(result.url).to.equal('');
+    expect(result.frame).to.equal(0);
+    expect(result.pixelDataFrame).to.equal(0);
+  });
+
+  it('should parse basic wadouri imageId', () => {
+    const result = parseImageId('wadouri:http://example.com/image.dcm');
+    expect(result.scheme).to.equal('wadouri');
+    expect(result.url).to.equal('http://example.com/image.dcm');
+    expect(result.frame).to.be.undefined;
+    expect(result.pixelDataFrame).to.be.undefined;
+  });
+
+  it('should parse frame using frame= pattern', () => {
+    const result = parseImageId('wadouri:http://example.com/image.dcm?frame=2');
+    expect(result.frame).to.equal(2);
+    expect(result.pixelDataFrame).to.equal(1);
+  });
+
+  it('should parse frame using frames/ pattern', () => {
+    const result = parseImageId(
+      'wadouri:http://example.com/frames/3/image.dcm'
+    );
+    expect(result.frame).to.equal(3);
+    expect(result.pixelDataFrame).to.equal(2);
+  });
+
+  it('should parse frame using frameNumber= pattern', () => {
+    const result = parseImageId(
+      'dicomweb:http://example.com/image.dcm?frameNumber=4'
+    );
+    expect(result.frame).to.equal(4);
+    expect(result.pixelDataFrame).to.equal(3);
+  });
+
+  it('should preserve content type and transfer syntax in URL', () => {
+    const result = parseImageId(
+      'wadouri:http://example.com/image.dcm?frame=2&contentType=application/dicom&transferSyntax=1.2.3'
+    );
+    expect(result.url).to.include('contentType=application/dicom');
+    expect(result.url).to.include('transferSyntax=1.2.3');
+  });
+});


### PR DESCRIPTION
WADO-URI multi-frame parameters were not being considered in the `parseImageId` method, which resulted in every frame of the multi-frame instance having its own URL, leading to each frame being requested separately.
