### PR TITLE
DVISA-2904: Fix first frame being skipped

### DIFF
--- a/packages/dicomImageLoader/package.json
+++ b/packages/dicomImageLoader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-dicom-image-loader",
-  "version": "1.86.0-ded11",
+  "version": "1.86.0-ded12",
   "description": "Cornerstone Image Loader for DICOM WADO-URI and WADO-RS and Local file",
   "keywords": [
     "DICOM",

--- a/packages/dicomImageLoader/src/imageLoader/wadouri/loadImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/loadImage.ts
@@ -216,7 +216,7 @@ function loadImage(
   return loadImageFromPromise(
     dataSetPromise,
     imageId,
-    parsedImageId.frame,
+    parsedImageId.pixelDataFrame,
     parsedImageId.url,
     options
   );


### PR DESCRIPTION
`loadImage` method does the initial image load (`loadImageFromPromise`) - to this method, the wrong parameter for the `frameIndex` was being passed: instead of the adjusted one (-1), the original frame index was being sent (whereas `dicomParser` expects the adjusted index).