### PR TITLE
DVISA-3365: Apply color palette to IVOTC series

### DIFF
--- a/packages/dicomImageLoader/package.json
+++ b/packages/dicomImageLoader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-dicom-image-loader",
-  "version": "1.86.0-ded13",
+  "version": "1.86.0-ded14",
   "description": "Cornerstone Image Loader for DICOM WADO-URI and WADO-RS and Local file",
   "keywords": [
     "DICOM",

--- a/packages/dicomImageLoader/package.json
+++ b/packages/dicomImageLoader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-dicom-image-loader",
-  "version": "1.86.0-ded14",
+  "version": "1.86.0-ded13",
   "description": "Cornerstone Image Loader for DICOM WADO-URI and WADO-RS and Local file",
   "keywords": [
     "DICOM",

--- a/packages/dicomImageLoader/src/imageLoader/getImageFrame.ts
+++ b/packages/dicomImageLoader/src/imageLoader/getImageFrame.ts
@@ -8,9 +8,30 @@ function getImageFrame(imageId: string): ImageFrame {
     imageId
   );
 
+  // Some modalities (e.g. IVOCT) store pixel data as MONOCHROME2 but signal
+  // that the image must be displayed with a color palette via Pixel Presentation
+  // (0008,9205) = 'COLOR' and the presence of palette LUT descriptors.
+  // Override photometricInterpretation to 'PALETTE COLOR' so the image is
+  // routed through the correct colour-rendering path in createImage.
+  // Guarded additionally on IVOCT SOP Class UIDs to prevent any other MONOCHROME2
+  // series that coincidentally carry these attributes from being misclassified.
+  const sopCommonModule =
+    cornerstone.metaData.get('sopCommonModule', imageId) || {};
+  const isIVOCT =
+    sopCommonModule.sopClassUID === '1.2.840.10008.5.1.4.1.1.14.1' ||
+    sopCommonModule.sopClassUID === '1.2.840.10008.5.1.4.1.1.14.2';
+
+  const photometricInterpretation =
+    imagePixelModule.photometricInterpretation === 'MONOCHROME2' &&
+    imagePixelModule.pixelPresentation === 'COLOR' &&
+    isIVOCT &&
+    imagePixelModule.redPaletteColorLookupTableDescriptor?.length
+      ? 'PALETTE COLOR'
+      : imagePixelModule.photometricInterpretation;
+
   return {
     samplesPerPixel: imagePixelModule.samplesPerPixel,
-    photometricInterpretation: imagePixelModule.photometricInterpretation,
+    photometricInterpretation,
     planarConfiguration: imagePixelModule.planarConfiguration,
     rows: imagePixelModule.rows,
     columns: imagePixelModule.columns,

--- a/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/getImagePixelModule.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/getImagePixelModule.ts
@@ -112,10 +112,17 @@ function populateSmallestLargestPixelValues(
   }
 }
 
+// IVOCT SOP Class UIDs (Intravascular Optical Coherence Tomography)
+const IVOCT_SOP_CLASS_UIDS = new Set([
+  '1.2.840.10008.5.1.4.1.1.14.1', // IVOCT Image Storage - For Presentation
+  '1.2.840.10008.5.1.4.1.1.14.2', // IVOCT Image Storage - For Processing
+]);
+
 function getImagePixelModule(dataSet: DataSet): MetadataImagePixelModule {
   const imagePixelModule = {
     samplesPerPixel: dataSet.uint16('x00280002'),
     photometricInterpretation: dataSet.string('x00280004'),
+    pixelPresentation: dataSet.string('x00089205'),
     rows: dataSet.uint16('x00280010'),
     columns: dataSet.uint16('x00280011'),
     bitsAllocated: dataSet.uint16('x00280100'),
@@ -128,8 +135,18 @@ function getImagePixelModule(dataSet: DataSet): MetadataImagePixelModule {
 
   populateSmallestLargestPixelValues(dataSet, imagePixelModule);
 
+  // Populate palette LUT data when:
+  //    Photometric Interpretation is 'PALETTE COLOR', OR
+  //    Photometric Interpretation is 'MONOCHROME2' AND Pixel Presentation
+  //    (0008,9205) is 'COLOR' AND the SOP Class UID identifies the image as
+  //    IVOCT
+  // In both cases the red palette LUT descriptor element must be present.
+  const sopClassUID = dataSet.string('x00080016');
   if (
-    imagePixelModule.photometricInterpretation === 'PALETTE COLOR' &&
+    (imagePixelModule.photometricInterpretation === 'PALETTE COLOR' ||
+      (imagePixelModule.photometricInterpretation === 'MONOCHROME2' &&
+        imagePixelModule.pixelPresentation === 'COLOR' &&
+        IVOCT_SOP_CLASS_UIDS.has(sopClassUID))) &&
     dataSet.elements.x00281101
   ) {
     populatePaletteColorLut(dataSet, imagePixelModule);

--- a/packages/dicomImageLoader/src/types/MetadataModules.ts
+++ b/packages/dicomImageLoader/src/types/MetadataModules.ts
@@ -53,6 +53,7 @@ export interface MetadataImagePlaneModule {
 export interface MetadataImagePixelModule {
   samplesPerPixel: number;
   photometricInterpretation: string;
+  pixelPresentation?: string;
   rows: number;
   columns: number;
   bitsAllocated: number;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

https://jira.dedalus.com/browse/DVISA-3365

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

IVOCT series have Photometric Interpretation = MONOCHROME2 and Pixel Presentation attribute = COLOR, and they carry a color palette that should be applied during rendering. With the changes in this PR, IVOCT images are now with their intended color palette.
